### PR TITLE
Fix filePicker path for Zotero 5.0.97

### DIFF
--- a/addon/chrome/content/lyz/lyz.js
+++ b/addon/chrome/content/lyz/lyz.js
@@ -410,13 +410,25 @@ Zotero.Lyz = {
     getFilePicker: async function() {
         const version = /^(\d+)\.(\d+)\.(\d+)/.exec(Zotero.version)
         const preFP = Zotero.platformMajorVersion < 60
+        let fp;
         if (preFP) {
             var nsIFilePicker = Components.interfaces.nsIFilePicker
-            var fp = Components.classes["@mozilla.org/filepicker;1"]
+            fp = Components.classes["@mozilla.org/filepicker;1"]
                     .createInstance(nsIFilePicker)
         } else {
-            var FilePicker = require('zotero/filePicker').default
-            var fp = new FilePicker()
+            let FilePicker;
+            if (
+                version["1"] == "5" &&
+                version["2"] == "0" &&
+                parseInt(version["3"], 10) < 97
+            ) {
+              Services.console.logStringMessage("old system")
+                FilePicker = require('zotero/filePicker').default
+            } else {
+              Services.console.logStringMessage("new system")
+                FilePicker = require('zotero/modules/filePicker').default
+            }
+            fp = new FilePicker()
         }
 
         return [preFP, fp]


### PR DESCRIPTION
Fixes #38.

Looking at the Zotero commit history, it looks like the path to the filePicker module changed recently in https://github.com/zotero/zotero/pull/2029. @dstillman and @adomasven, could one of you confirm that this is the right way to handle the old and new filePicker paths (looking for version 5.0.96 and under)?